### PR TITLE
Fix not running (cannot read property of 'val')

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -9,7 +9,7 @@ const translateClient = Translate({
 // russian auto-translate
 exports.translateToRussian = functions.database
     .ref('/trollbox/{messageId}')
-    .onWrite(event => {
+    .onWrite((event, context) => {
         const translated = event.data.val().translated;
         if (!translated) {
             const origTxt = event.data.val().message;


### PR DESCRIPTION
Error: TypeError: Cannot read property 'val' of undefined
Solution: https://firebase.google.com/docs/functions/beta-v1-diff#realtime-database

from: event => 
to: (event, context) =>